### PR TITLE
Add sock inventory tool

### DIFF
--- a/lib/mcpServer.ts
+++ b/lib/mcpServer.ts
@@ -126,21 +126,17 @@ export const initializeMCPServer = (server: McpServer) => {
   );
 
   // Fetch sock inventory tool
-  server.tool(
-    'checkInventory',
-    'Check what socks are available',
-    async () => {
-      const socks = await OrderService.socks();
+  server.tool('checkInventory', 'Check what socks are available', async () => {
+    const socks = await OrderService.socks();
 
-        return {
-          content: socks.map(sock => ({
-            ...sock,
-            type: 'text',
-            text: `${sock.description} (ID: ${sock.sock_id})`,
-          })),
-      };
-    }
-  );
+    return {
+      content: socks.map(sock => ({
+        ...sock,
+        type: 'text',
+        text: `${sock.description} (ID: ${sock.sock_id})`,
+      })),
+    };
+  });
 
   // Place sock order tool
   server.tool(

--- a/lib/mcpServer.ts
+++ b/lib/mcpServer.ts
@@ -125,6 +125,23 @@ export const initializeMCPServer = (server: McpServer) => {
     }
   );
 
+  // Fetch sock inventory tool
+  server.tool(
+    'checkInventory',
+    'Check what socks are available',
+    async () => {
+      const socks = await OrderService.socks();
+
+        return {
+          content: socks.map(sock => ({
+            ...sock,
+            type: 'text',
+            text: `${sock.description} (ID: ${sock.sock_id})`,
+          })),
+      };
+    }
+  );
+
   // Place sock order tool
   server.tool(
     'placeSockOrder',


### PR DESCRIPTION
I'm almost successfully using https://docs.claude.com/en/docs/agents-and-tools/mcp-connector to connect to the socks mcp server, which is very cool, but only supports tool calls, not resources.  

This just adds an inventory tool that does that same thing as the resource.