### PR TITLE
chore: use custom telemetry domain

### DIFF
--- a/app/fraud/fingerprint/page.tsx
+++ b/app/fraud/fingerprint/page.tsx
@@ -16,6 +16,7 @@ function FraudFingerprintContent() {
         // Get telemetry ID
         const telemetryId = await GetTelemetryID({
           publicToken: process.env.NEXT_PUBLIC_STYTCH_PUBLIC_TOKEN!,
+          submitURL: 'fp.shophellosocks.com',
         });
 
         // Build the redirect URL with all current search params plus telemetry_id

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -27,6 +27,7 @@ function LoginForm() {
           email,
           telemetry_id: await GetTelemetryID({
             publicToken: process.env.NEXT_PUBLIC_STYTCH_PUBLIC_TOKEN!,
+            submitURL: 'fp.shophellosocks.com',
           }),
         }),
       });

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,5 +1,5 @@
 declare global {
-  function GetTelemetryID(params: { publicToken: string }): Promise<string>;
+  function GetTelemetryID(params: { publicToken: string, submitURL: string }): Promise<string>;
 }
 
 export {};

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,5 +1,8 @@
 declare global {
-  function GetTelemetryID(params: { publicToken: string, submitURL: string }): Promise<string>;
+  function GetTelemetryID(params: {
+    publicToken: string;
+    submitURL: string;
+  }): Promise<string>;
 }
 
 export {};


### PR DESCRIPTION
This should help showcase telemetry in action without getting blocked by AdBlock, which currently sinks requests to `telemetry.stytch.com`.